### PR TITLE
Currency ve unit test iyileştirmeleri

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 vendor
 *.lock
+tests/testresults/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -15,4 +15,40 @@ $ composer require ibrahimgunduz34/payuclient:dev-master
 
 Entegrasyon detayları ile ilgili dökümanları [buraya tıklayarak](/docs/index.md) inceleyebilirsiniz.
 
+# Unit Test'lerin Çalıştırılması
+Unit testleri çalıştırmak için sisteminizde [PHPUnit](https://phpunit.de) kurulu olmalıdır.
+
+PHPUnit'i çalıştırılabilir PHP Arşiv Paketi (PHAR) halinde kurmak için:
+
+```
+$ wget https://phar.phpunit.de/phpunit.phar
+$ chmod +x phpunit.phar
+$ mv phpunit.phar /usr/local/bin/phpunit
+```
+
+veya Mac OS X kullanıcısı iseniz [Homebrew](http://brew.sh/) yardımıyla kurmak için:
+
+```
+$ brew update
+$ brew install phpunit
+```
+
+komutlarını vermeniz yeterlidir. Kurulum sonrası unit testleri çalıştırmak için aşağıdaki komutu verebilirsiniz:
+
+```
+$ cd /path/to/payuclient
+$ phpunit -c tests/phpunit.xml
+
+PHPUnit 3.7.38 by Sebastian Bergmann.
+Configuration read from payuclient/tests/phpunit.xml
+
+........................
+
+Time: 1.58 seconds, Memory: 6.75Mb
+
+OK (24 tests, 27 assertions)
+```
+
+---
+
 Katkıda bulunan geliştiriciler için [buraya tıklayınız](/docs/contributors.md)

--- a/src/Payu/Component/Currency.php
+++ b/src/Payu/Component/Currency.php
@@ -1,12 +1,28 @@
 <?php
+/**
+ * Payuclient currency component
+ */
 namespace Payu\Component;
 
+/**
+ * Currency class for represent currencies.
+ */
 class Currency implements ComponentInterface
 {
     /**
-     * @var string
+     * @var string Three letter ISO-4217 currency code.
      */
     private $code;
+
+    /**
+     * Constructor
+     *
+     * @param string $code Three letter currency code.
+     */
+    public function __construct($code = null)
+    {
+        $this->code = static::filterAndValidateCurrencyCode($code);
+    }
 
     /**
      * @return string
@@ -17,14 +33,256 @@ class Currency implements ComponentInterface
     }
 
     /**
+     * Sets currency code.
+     *
+     * @throws \InvalidArgumentException
      * @param string $code
      */
     public function setCode($code)
     {
-        $this->code = $code;
+        $this->code = static::filterAndValidateCurrencyCode($code);
+
+        return $this;
     }
 
-    public function __construct($code = null) {
-        $this->code = $code;
+    /**
+     * Filters and validates given currency code.
+     *
+     * @param  string $code Currency code to filter and validate.
+     * @throws \InvalidArgumentException
+     * @return string Three letter currency code.
+     */
+    public static function filterAndValidateCurrencyCode($code)
+    {
+        $code = strtoupper(preg_replace('/[^a-zA-Z]/', '', $code));
+
+        if (array_key_exists($code, static::getAvailableCurrencies()) === false) {
+            throw new \InvalidArgumentException('Currency code "'.$code.'" is not a valid ISO 4217 symbol');
+        }
+
+        return $code;
+    }
+
+    /**
+     * Returns currency name for rendering purposes.
+     *
+     * Example:
+     *   $label = Currency::getNameByCode('TRY');
+     *   // $label is "Turkish Lira"
+     *
+     * @param  string $code
+     *
+     * @return string Currency name as string
+     */
+    public static function getNameByCode($code)
+    {
+        $codes = static::getAvailableCurrencies();
+
+        if (array_key_exists($code, $codes)) {
+            return $codes[$code];
+        }
+
+        return;
+    }
+
+    /**
+     * Returns official list of ISO 4217 currency codes.
+     *
+     * @link http://www.iso.org/iso/home/standards/currency_codes.htm
+     *
+     * @return array
+     */
+    public static function getAvailableCurrencies()
+    {
+        return array(
+          'AFN' => 'Afghani',
+          'EUR' => 'Euro',
+          'ALL' => 'Lek',
+          'DZD' => 'Algerian Dinar',
+          'USD' => 'US Dollar',
+          'AOA' => 'Kwanza',
+          'XCD' => 'East Caribbean Dollar',
+          'ARS' => 'Argentine Peso',
+          'AMD' => 'Armenian Dram',
+          'AWG' => 'Aruban Florin',
+          'AUD' => 'Australian Dollar',
+          'AZN' => 'Azerbaijanian Manat',
+          'BSD' => 'Bahamian Dollar',
+          'BHD' => 'Bahraini Dinar',
+          'BDT' => 'Taka',
+          'BBD' => 'Barbados Dollar',
+          'BYR' => 'Belarussian Ruble',
+          'BZD' => 'Belize Dollar',
+          'XOF' => 'CFA Franc BCEAO',
+          'BMD' => 'Bermudian Dollar',
+          'BTN' => 'Ngultrum',
+          'INR' => 'Indian Rupee',
+          'BOB' => 'Boliviano',
+          'BOV' => 'Mvdol',
+          'BAM' => 'Convertible Mark',
+          'BWP' => 'Pula',
+          'NOK' => 'Norwegian Krone',
+          'BRL' => 'Brazilian Real',
+          'BND' => 'Brunei Dollar',
+          'BGN' => 'Bulgarian Lev',
+          'BIF' => 'Burundi Franc',
+          'CVE' => 'Cabo Verde Escudo',
+          'KHR' => 'Riel',
+          'XAF' => 'CFA Franc BEAC',
+          'CAD' => 'Canadian Dollar',
+          'KYD' => 'Cayman Islands Dollar',
+          'CLF' => 'Unidad de Fomento',
+          'CLP' => 'Chilean Peso',
+          'CNY' => 'Yuan Renminbi',
+          'COP' => 'Colombian Peso',
+          'COU' => 'Unidad de Valor Real',
+          'KMF' => 'Comoro Franc',
+          'CDF' => 'Congolese Franc',
+          'NZD' => 'New Zealand Dollar',
+          'CRC' => 'Costa Rican Colon',
+          'HRK' => 'Kuna',
+          'CUC' => 'Peso Convertible',
+          'CUP' => 'Cuban Peso',
+          'ANG' => 'Netherlands Antillean Guilder',
+          'CZK' => 'Czech Koruna',
+          'DKK' => 'Danish Krone',
+          'DJF' => 'Djibouti Franc',
+          'DOP' => 'Dominican Peso',
+          'EGP' => 'Egyptian Pound',
+          'SVC' => 'El Salvador Colon',
+          'ERN' => 'Nakfa',
+          'ETB' => 'Ethiopian Birr',
+          'FKP' => 'Falkland Islands Pound',
+          'FJD' => 'Fiji Dollar',
+          'XPF' => 'CFP Franc',
+          'GMD' => 'Dalasi',
+          'GEL' => 'Lari',
+          'GHS' => 'Ghana Cedi',
+          'GIP' => 'Gibraltar Pound',
+          'GTQ' => 'Quetzal',
+          'GBP' => 'Pound Sterling',
+          'GNF' => 'Guinea Franc',
+          'GYD' => 'Guyana Dollar',
+          'HTG' => 'Gourde',
+          'HNL' => 'Lempira',
+          'HKD' => 'Hong Kong Dollar',
+          'HUF' => 'Forint',
+          'ISK' => 'Iceland Krona',
+          'IDR' => 'Rupiah',
+          'XDR' => 'SDR Special Drawing Right',
+          'IRR' => 'Iranian Rial',
+          'IQD' => 'Iraqi Dinar',
+          'ILS' => 'New Israeli Sheqel',
+          'JMD' => 'Jamaican Dollar',
+          'JPY' => 'Yen',
+          'JOD' => 'Jordanian Dinar',
+          'KZT' => 'Tenge',
+          'KES' => 'Kenyan Shilling',
+          'KPW' => 'North Korean Won',
+          'KRW' => 'Won',
+          'KWD' => 'Kuwaiti Dinar',
+          'KGS' => 'Som',
+          'LAK' => 'Kip',
+          'LBP' => 'Lebanese Pound',
+          'LSL' => 'Loti',
+          'ZAR' => 'Rand',
+          'LRD' => 'Liberian Dollar',
+          'LYD' => 'Libyan Dinar',
+          'CHF' => 'Swiss Franc',
+          'MOP' => 'Pataca',
+          'MKD' => 'Denar',
+          'MGA' => 'Malagasy Ariary',
+          'MWK' => 'Kwacha',
+          'MYR' => 'Malaysian Ringgit',
+          'MVR' => 'Rufiyaa',
+          'MRO' => 'Ouguiya',
+          'MUR' => 'Mauritius Rupee',
+          'XUA' => 'ADB Unit of Account',
+          'MXN' => 'Mexican Peso',
+          'MXV' => 'Mexican Unidad de Inversion UDI',
+          'MDL' => 'Moldovan Leu',
+          'MNT' => 'Tugrik',
+          'MAD' => 'Moroccan Dirham',
+          'MZN' => 'Mozambique Metical',
+          'MMK' => 'Kyat',
+          'NAD' => 'Namibia Dollar',
+          'NPR' => 'Nepalese Rupee',
+          'NIO' => 'Cordoba Oro',
+          'NGN' => 'Naira',
+          'OMR' => 'Rial Omani',
+          'PKR' => 'Pakistan Rupee',
+          'PAB' => 'Balboa',
+          'PGK' => 'Kina',
+          'PYG' => 'Guarani',
+          'PEN' => 'Nuevo Sol',
+          'PHP' => 'Philippine Peso',
+          'PLN' => 'Zloty',
+          'QAR' => 'Qatari Rial',
+          'RON' => 'Romanian Leu',
+          'RUB' => 'Russian Ruble',
+          'RWF' => 'Rwanda Franc',
+          'SHP' => 'Saint Helena Pound',
+          'WST' => 'Tala',
+          'STD' => 'Dobra',
+          'SAR' => 'Saudi Riyal',
+          'RSD' => 'Serbian Dinar',
+          'SCR' => 'Seychelles Rupee',
+          'SLL' => 'Leone',
+          'SGD' => 'Singapore Dollar',
+          'XSU' => 'Sucre',
+          'SBD' => 'Solomon Islands Dollar',
+          'SOS' => 'Somali Shilling',
+          'SSP' => 'South Sudanese Pound',
+          'LKR' => 'Sri Lanka Rupee',
+          'SDG' => 'Sudanese Pound',
+          'SRD' => 'Surinam Dollar',
+          'SZL' => 'Lilangeni',
+          'SEK' => 'Swedish Krona',
+          'CHE' => 'WIR Euro',
+          'CHW' => 'WIR Franc',
+          'SYP' => 'Syrian Pound',
+          'TWD' => 'New Taiwan Dollar',
+          'TJS' => 'Somoni',
+          'TZS' => 'Tanzanian Shilling',
+          'THB' => 'Baht',
+          'TOP' => 'Paanga',
+          'TTD' => 'Trinidad and Tobago Dollar',
+          'TND' => 'Tunisian Dinar',
+          'TRY' => 'Turkish Lira',
+          'TMT' => 'Turkmenistan New Manat',
+          'UGX' => 'Uganda Shilling',
+          'UAH' => 'Hryvnia',
+          'AED' => 'UAE Dirham',
+          'USN' => 'US Dollar Next day',
+          'UYI' => 'Uruguay Peso en Unidades Indexadas URUIURUI',
+          'UYU' => 'Peso Uruguayo',
+          'UZS' => 'Uzbekistan Sum',
+          'VUV' => 'Vatu',
+          'VEF' => 'Bolivar',
+          'VND' => 'Dong',
+          'YER' => 'Yemeni Rial',
+          'ZMW' => 'Zambian Kwacha',
+          'ZWL' => 'Zimbabwe Dollar',
+          'XBA' => 'Bond Markets Unit European Composite Unit EURCO',
+          'XBB' => 'Bond Markets Unit European Monetary Unit EMU6',
+          'XBC' => 'Bond Markets Unit European Unit of Account 9 EUA9',
+          'XBD' => 'Bond Markets Unit European Unit of Account 17 EUA17',
+          'XTS' => 'Codes specifically reserved for testing purposes',
+          'XAU' => 'Gold',
+          'XPD' => 'Palladium',
+          'XPT' => 'Platinum',
+          'XAG' => 'Silver',
+        );
+    }
+
+    /**
+     * Returns string representation of the currency
+     * instance in case of casting to string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->code;
     }
 }

--- a/src/Payu/Component/Currency.php
+++ b/src/Payu/Component/Currency.php
@@ -21,7 +21,7 @@ class Currency implements ComponentInterface
      */
     public function __construct($code = null)
     {
-        $this->code = static::filterAndValidateCurrencyCode($code);
+        $this->setCode($code);
     }
 
     /**
@@ -35,249 +35,19 @@ class Currency implements ComponentInterface
     /**
      * Sets currency code.
      *
-     * @throws \InvalidArgumentException
      * @param string $code
      */
     public function setCode($code)
     {
-        $this->code = static::filterAndValidateCurrencyCode($code);
+        // Always use uppercase currency codes internally
+        $this->code = strtoupper(preg_replace('/[^a-zA-Z]/', '', $code));
 
         return $this;
     }
 
     /**
-     * Filters and validates given currency code.
-     *
-     * @param  string $code Currency code to filter and validate.
-     * @throws \InvalidArgumentException
-     * @return string Three letter currency code.
-     */
-    public static function filterAndValidateCurrencyCode($code)
-    {
-        $code = strtoupper(preg_replace('/[^a-zA-Z]/', '', $code));
-
-        if (array_key_exists($code, static::getAvailableCurrencies()) === false) {
-            throw new \InvalidArgumentException('Currency code "'.$code.'" is not a valid ISO 4217 symbol');
-        }
-
-        return $code;
-    }
-
-    /**
-     * Returns currency name for rendering purposes.
-     *
-     * Example:
-     *   $label = Currency::getNameByCode('TRY');
-     *   // $label is "Turkish Lira"
-     *
-     * @param  string $code
-     *
-     * @return string Currency name as string
-     */
-    public static function getNameByCode($code)
-    {
-        $codes = static::getAvailableCurrencies();
-
-        if (array_key_exists($code, $codes)) {
-            return $codes[$code];
-        }
-
-        return;
-    }
-
-    /**
-     * Returns official list of ISO 4217 currency codes.
-     *
-     * @link http://www.iso.org/iso/home/standards/currency_codes.htm
-     *
-     * @return array
-     */
-    public static function getAvailableCurrencies()
-    {
-        return array(
-          'AFN' => 'Afghani',
-          'EUR' => 'Euro',
-          'ALL' => 'Lek',
-          'DZD' => 'Algerian Dinar',
-          'USD' => 'US Dollar',
-          'AOA' => 'Kwanza',
-          'XCD' => 'East Caribbean Dollar',
-          'ARS' => 'Argentine Peso',
-          'AMD' => 'Armenian Dram',
-          'AWG' => 'Aruban Florin',
-          'AUD' => 'Australian Dollar',
-          'AZN' => 'Azerbaijanian Manat',
-          'BSD' => 'Bahamian Dollar',
-          'BHD' => 'Bahraini Dinar',
-          'BDT' => 'Taka',
-          'BBD' => 'Barbados Dollar',
-          'BYR' => 'Belarussian Ruble',
-          'BZD' => 'Belize Dollar',
-          'XOF' => 'CFA Franc BCEAO',
-          'BMD' => 'Bermudian Dollar',
-          'BTN' => 'Ngultrum',
-          'INR' => 'Indian Rupee',
-          'BOB' => 'Boliviano',
-          'BOV' => 'Mvdol',
-          'BAM' => 'Convertible Mark',
-          'BWP' => 'Pula',
-          'NOK' => 'Norwegian Krone',
-          'BRL' => 'Brazilian Real',
-          'BND' => 'Brunei Dollar',
-          'BGN' => 'Bulgarian Lev',
-          'BIF' => 'Burundi Franc',
-          'CVE' => 'Cabo Verde Escudo',
-          'KHR' => 'Riel',
-          'XAF' => 'CFA Franc BEAC',
-          'CAD' => 'Canadian Dollar',
-          'KYD' => 'Cayman Islands Dollar',
-          'CLF' => 'Unidad de Fomento',
-          'CLP' => 'Chilean Peso',
-          'CNY' => 'Yuan Renminbi',
-          'COP' => 'Colombian Peso',
-          'COU' => 'Unidad de Valor Real',
-          'KMF' => 'Comoro Franc',
-          'CDF' => 'Congolese Franc',
-          'NZD' => 'New Zealand Dollar',
-          'CRC' => 'Costa Rican Colon',
-          'HRK' => 'Kuna',
-          'CUC' => 'Peso Convertible',
-          'CUP' => 'Cuban Peso',
-          'ANG' => 'Netherlands Antillean Guilder',
-          'CZK' => 'Czech Koruna',
-          'DKK' => 'Danish Krone',
-          'DJF' => 'Djibouti Franc',
-          'DOP' => 'Dominican Peso',
-          'EGP' => 'Egyptian Pound',
-          'SVC' => 'El Salvador Colon',
-          'ERN' => 'Nakfa',
-          'ETB' => 'Ethiopian Birr',
-          'FKP' => 'Falkland Islands Pound',
-          'FJD' => 'Fiji Dollar',
-          'XPF' => 'CFP Franc',
-          'GMD' => 'Dalasi',
-          'GEL' => 'Lari',
-          'GHS' => 'Ghana Cedi',
-          'GIP' => 'Gibraltar Pound',
-          'GTQ' => 'Quetzal',
-          'GBP' => 'Pound Sterling',
-          'GNF' => 'Guinea Franc',
-          'GYD' => 'Guyana Dollar',
-          'HTG' => 'Gourde',
-          'HNL' => 'Lempira',
-          'HKD' => 'Hong Kong Dollar',
-          'HUF' => 'Forint',
-          'ISK' => 'Iceland Krona',
-          'IDR' => 'Rupiah',
-          'XDR' => 'SDR Special Drawing Right',
-          'IRR' => 'Iranian Rial',
-          'IQD' => 'Iraqi Dinar',
-          'ILS' => 'New Israeli Sheqel',
-          'JMD' => 'Jamaican Dollar',
-          'JPY' => 'Yen',
-          'JOD' => 'Jordanian Dinar',
-          'KZT' => 'Tenge',
-          'KES' => 'Kenyan Shilling',
-          'KPW' => 'North Korean Won',
-          'KRW' => 'Won',
-          'KWD' => 'Kuwaiti Dinar',
-          'KGS' => 'Som',
-          'LAK' => 'Kip',
-          'LBP' => 'Lebanese Pound',
-          'LSL' => 'Loti',
-          'ZAR' => 'Rand',
-          'LRD' => 'Liberian Dollar',
-          'LYD' => 'Libyan Dinar',
-          'CHF' => 'Swiss Franc',
-          'MOP' => 'Pataca',
-          'MKD' => 'Denar',
-          'MGA' => 'Malagasy Ariary',
-          'MWK' => 'Kwacha',
-          'MYR' => 'Malaysian Ringgit',
-          'MVR' => 'Rufiyaa',
-          'MRO' => 'Ouguiya',
-          'MUR' => 'Mauritius Rupee',
-          'XUA' => 'ADB Unit of Account',
-          'MXN' => 'Mexican Peso',
-          'MXV' => 'Mexican Unidad de Inversion UDI',
-          'MDL' => 'Moldovan Leu',
-          'MNT' => 'Tugrik',
-          'MAD' => 'Moroccan Dirham',
-          'MZN' => 'Mozambique Metical',
-          'MMK' => 'Kyat',
-          'NAD' => 'Namibia Dollar',
-          'NPR' => 'Nepalese Rupee',
-          'NIO' => 'Cordoba Oro',
-          'NGN' => 'Naira',
-          'OMR' => 'Rial Omani',
-          'PKR' => 'Pakistan Rupee',
-          'PAB' => 'Balboa',
-          'PGK' => 'Kina',
-          'PYG' => 'Guarani',
-          'PEN' => 'Nuevo Sol',
-          'PHP' => 'Philippine Peso',
-          'PLN' => 'Zloty',
-          'QAR' => 'Qatari Rial',
-          'RON' => 'Romanian Leu',
-          'RUB' => 'Russian Ruble',
-          'RWF' => 'Rwanda Franc',
-          'SHP' => 'Saint Helena Pound',
-          'WST' => 'Tala',
-          'STD' => 'Dobra',
-          'SAR' => 'Saudi Riyal',
-          'RSD' => 'Serbian Dinar',
-          'SCR' => 'Seychelles Rupee',
-          'SLL' => 'Leone',
-          'SGD' => 'Singapore Dollar',
-          'XSU' => 'Sucre',
-          'SBD' => 'Solomon Islands Dollar',
-          'SOS' => 'Somali Shilling',
-          'SSP' => 'South Sudanese Pound',
-          'LKR' => 'Sri Lanka Rupee',
-          'SDG' => 'Sudanese Pound',
-          'SRD' => 'Surinam Dollar',
-          'SZL' => 'Lilangeni',
-          'SEK' => 'Swedish Krona',
-          'CHE' => 'WIR Euro',
-          'CHW' => 'WIR Franc',
-          'SYP' => 'Syrian Pound',
-          'TWD' => 'New Taiwan Dollar',
-          'TJS' => 'Somoni',
-          'TZS' => 'Tanzanian Shilling',
-          'THB' => 'Baht',
-          'TOP' => 'Paanga',
-          'TTD' => 'Trinidad and Tobago Dollar',
-          'TND' => 'Tunisian Dinar',
-          'TRY' => 'Turkish Lira',
-          'TMT' => 'Turkmenistan New Manat',
-          'UGX' => 'Uganda Shilling',
-          'UAH' => 'Hryvnia',
-          'AED' => 'UAE Dirham',
-          'USN' => 'US Dollar Next day',
-          'UYI' => 'Uruguay Peso en Unidades Indexadas URUIURUI',
-          'UYU' => 'Peso Uruguayo',
-          'UZS' => 'Uzbekistan Sum',
-          'VUV' => 'Vatu',
-          'VEF' => 'Bolivar',
-          'VND' => 'Dong',
-          'YER' => 'Yemeni Rial',
-          'ZMW' => 'Zambian Kwacha',
-          'ZWL' => 'Zimbabwe Dollar',
-          'XBA' => 'Bond Markets Unit European Composite Unit EURCO',
-          'XBB' => 'Bond Markets Unit European Monetary Unit EMU6',
-          'XBC' => 'Bond Markets Unit European Unit of Account 9 EUA9',
-          'XBD' => 'Bond Markets Unit European Unit of Account 17 EUA17',
-          'XTS' => 'Codes specifically reserved for testing purposes',
-          'XAU' => 'Gold',
-          'XPD' => 'Palladium',
-          'XPT' => 'Platinum',
-          'XAG' => 'Silver',
-        );
-    }
-
-    /**
      * Returns string representation of the currency
-     * instance in case of casting to string.
+     * instance in case of casting a currency instance to string.
      *
      * @return string
      */

--- a/src/Payu/Component/Order.php
+++ b/src/Payu/Component/Order.php
@@ -78,6 +78,7 @@ class Order implements ComponentInterface
     public function setClientIp($clientIp)
     {
         $this->clientIp = $clientIp;
+
         return $this;
     }
 
@@ -96,6 +97,7 @@ class Order implements ComponentInterface
     public function setCode($code)
     {
         $this->code = $code;
+
         return $this;
     }
 
@@ -114,6 +116,7 @@ class Order implements ComponentInterface
     public function setCurrency($currency)
     {
         $this->currency = $currency;
+        
         return $this;
     }
 
@@ -132,6 +135,7 @@ class Order implements ComponentInterface
     public function setDate($date)
     {
         $this->date = $date != null ? $date : gmdate('Y-m-d H:i:s');
+
         return $this;
     }
 
@@ -150,6 +154,7 @@ class Order implements ComponentInterface
     public function setInstallment($installment)
     {
         $this->installment = $installment;
+
         return $this;
     }
 
@@ -168,6 +173,7 @@ class Order implements ComponentInterface
     public function setLoyaltyAmount($loyaltyAmount)
     {
         $this->loyaltyAmount = $loyaltyAmount;
+
         return $this;
     }
 
@@ -186,6 +192,7 @@ class Order implements ComponentInterface
     public function setPaymentMethod($paymentMethod)
     {
         $this->paymentMethod = $paymentMethod;
+
         return $this;
     }
 
@@ -204,6 +211,7 @@ class Order implements ComponentInterface
     public function setTimeout($timeout)
     {
         $this->timeout = $timeout;
+
         return $this;
     }
 

--- a/src/Payu/Validator/Validator/OrderValidator.php
+++ b/src/Payu/Validator/Validator/OrderValidator.php
@@ -6,7 +6,6 @@ use Payu\Exception\ValidationError;
 
 class OrderValidator extends ValidatorAbstract
 {
-
     /**
      * @return void
      * @throws \Payu\Exception\ValidationError
@@ -26,8 +25,224 @@ class OrderValidator extends ValidatorAbstract
          * @var $object \Payu\Component\Order
          */
         $object = $this->request->getOrder();
-        if(!$object || !$object instanceof Order) {
+        
+        if (!$object || !$object instanceof Order) {
             throw new ValidationError('Order does not be empty.');
         }
+
+        // Get currency from order instance
+        try {
+            static::filterAndValidateCurrencyCode($object->getCurrency());
+        } catch (\Exception $e) {
+            throw new ValidationError($e->getMessage());
+        }
+    }
+
+    /**
+     * Filters and validates given currency code.
+     *
+     * @param  string $code Currency code to filter and validate.
+     * @throws \InvalidArgumentException
+     * @return string Three letter currency code.
+     */
+    public static function filterAndValidateCurrencyCode($code)
+    {
+        $code = strtoupper(preg_replace('/[^a-zA-Z]/', '', $code));
+
+        if (array_key_exists($code, static::getAvailableCurrencies()) === false) {
+            throw new \InvalidArgumentException('Currency code "'.$code.'" is not a valid ISO 4217 symbol');
+        }
+
+        return $code;
+    }
+
+    /**
+     * Returns official list of ISO 4217 currency codes.
+     *
+     * @link http://www.iso.org/iso/home/standards/currency_codes.htm
+     *
+     * @return array
+     */
+    public static function getAvailableCurrencies()
+    {
+        return array(
+          'AFN' => 'Afghani',
+          'EUR' => 'Euro',
+          'ALL' => 'Lek',
+          'DZD' => 'Algerian Dinar',
+          'USD' => 'US Dollar',
+          'AOA' => 'Kwanza',
+          'XCD' => 'East Caribbean Dollar',
+          'ARS' => 'Argentine Peso',
+          'AMD' => 'Armenian Dram',
+          'AWG' => 'Aruban Florin',
+          'AUD' => 'Australian Dollar',
+          'AZN' => 'Azerbaijanian Manat',
+          'BSD' => 'Bahamian Dollar',
+          'BHD' => 'Bahraini Dinar',
+          'BDT' => 'Taka',
+          'BBD' => 'Barbados Dollar',
+          'BYR' => 'Belarussian Ruble',
+          'BZD' => 'Belize Dollar',
+          'XOF' => 'CFA Franc BCEAO',
+          'BMD' => 'Bermudian Dollar',
+          'BTN' => 'Ngultrum',
+          'INR' => 'Indian Rupee',
+          'BOB' => 'Boliviano',
+          'BOV' => 'Mvdol',
+          'BAM' => 'Convertible Mark',
+          'BWP' => 'Pula',
+          'NOK' => 'Norwegian Krone',
+          'BRL' => 'Brazilian Real',
+          'BND' => 'Brunei Dollar',
+          'BGN' => 'Bulgarian Lev',
+          'BIF' => 'Burundi Franc',
+          'CVE' => 'Cabo Verde Escudo',
+          'KHR' => 'Riel',
+          'XAF' => 'CFA Franc BEAC',
+          'CAD' => 'Canadian Dollar',
+          'KYD' => 'Cayman Islands Dollar',
+          'CLF' => 'Unidad de Fomento',
+          'CLP' => 'Chilean Peso',
+          'CNY' => 'Yuan Renminbi',
+          'COP' => 'Colombian Peso',
+          'COU' => 'Unidad de Valor Real',
+          'KMF' => 'Comoro Franc',
+          'CDF' => 'Congolese Franc',
+          'NZD' => 'New Zealand Dollar',
+          'CRC' => 'Costa Rican Colon',
+          'HRK' => 'Kuna',
+          'CUC' => 'Peso Convertible',
+          'CUP' => 'Cuban Peso',
+          'ANG' => 'Netherlands Antillean Guilder',
+          'CZK' => 'Czech Koruna',
+          'DKK' => 'Danish Krone',
+          'DJF' => 'Djibouti Franc',
+          'DOP' => 'Dominican Peso',
+          'EGP' => 'Egyptian Pound',
+          'SVC' => 'El Salvador Colon',
+          'ERN' => 'Nakfa',
+          'ETB' => 'Ethiopian Birr',
+          'FKP' => 'Falkland Islands Pound',
+          'FJD' => 'Fiji Dollar',
+          'XPF' => 'CFP Franc',
+          'GMD' => 'Dalasi',
+          'GEL' => 'Lari',
+          'GHS' => 'Ghana Cedi',
+          'GIP' => 'Gibraltar Pound',
+          'GTQ' => 'Quetzal',
+          'GBP' => 'Pound Sterling',
+          'GNF' => 'Guinea Franc',
+          'GYD' => 'Guyana Dollar',
+          'HTG' => 'Gourde',
+          'HNL' => 'Lempira',
+          'HKD' => 'Hong Kong Dollar',
+          'HUF' => 'Forint',
+          'ISK' => 'Iceland Krona',
+          'IDR' => 'Rupiah',
+          'XDR' => 'SDR Special Drawing Right',
+          'IRR' => 'Iranian Rial',
+          'IQD' => 'Iraqi Dinar',
+          'ILS' => 'New Israeli Sheqel',
+          'JMD' => 'Jamaican Dollar',
+          'JPY' => 'Yen',
+          'JOD' => 'Jordanian Dinar',
+          'KZT' => 'Tenge',
+          'KES' => 'Kenyan Shilling',
+          'KPW' => 'North Korean Won',
+          'KRW' => 'Won',
+          'KWD' => 'Kuwaiti Dinar',
+          'KGS' => 'Som',
+          'LAK' => 'Kip',
+          'LBP' => 'Lebanese Pound',
+          'LSL' => 'Loti',
+          'ZAR' => 'Rand',
+          'LRD' => 'Liberian Dollar',
+          'LYD' => 'Libyan Dinar',
+          'CHF' => 'Swiss Franc',
+          'MOP' => 'Pataca',
+          'MKD' => 'Denar',
+          'MGA' => 'Malagasy Ariary',
+          'MWK' => 'Kwacha',
+          'MYR' => 'Malaysian Ringgit',
+          'MVR' => 'Rufiyaa',
+          'MRO' => 'Ouguiya',
+          'MUR' => 'Mauritius Rupee',
+          'XUA' => 'ADB Unit of Account',
+          'MXN' => 'Mexican Peso',
+          'MXV' => 'Mexican Unidad de Inversion UDI',
+          'MDL' => 'Moldovan Leu',
+          'MNT' => 'Tugrik',
+          'MAD' => 'Moroccan Dirham',
+          'MZN' => 'Mozambique Metical',
+          'MMK' => 'Kyat',
+          'NAD' => 'Namibia Dollar',
+          'NPR' => 'Nepalese Rupee',
+          'NIO' => 'Cordoba Oro',
+          'NGN' => 'Naira',
+          'OMR' => 'Rial Omani',
+          'PKR' => 'Pakistan Rupee',
+          'PAB' => 'Balboa',
+          'PGK' => 'Kina',
+          'PYG' => 'Guarani',
+          'PEN' => 'Nuevo Sol',
+          'PHP' => 'Philippine Peso',
+          'PLN' => 'Zloty',
+          'QAR' => 'Qatari Rial',
+          'RON' => 'Romanian Leu',
+          'RUB' => 'Russian Ruble',
+          'RWF' => 'Rwanda Franc',
+          'SHP' => 'Saint Helena Pound',
+          'WST' => 'Tala',
+          'STD' => 'Dobra',
+          'SAR' => 'Saudi Riyal',
+          'RSD' => 'Serbian Dinar',
+          'SCR' => 'Seychelles Rupee',
+          'SLL' => 'Leone',
+          'SGD' => 'Singapore Dollar',
+          'XSU' => 'Sucre',
+          'SBD' => 'Solomon Islands Dollar',
+          'SOS' => 'Somali Shilling',
+          'SSP' => 'South Sudanese Pound',
+          'LKR' => 'Sri Lanka Rupee',
+          'SDG' => 'Sudanese Pound',
+          'SRD' => 'Surinam Dollar',
+          'SZL' => 'Lilangeni',
+          'SEK' => 'Swedish Krona',
+          'CHE' => 'WIR Euro',
+          'CHW' => 'WIR Franc',
+          'SYP' => 'Syrian Pound',
+          'TWD' => 'New Taiwan Dollar',
+          'TJS' => 'Somoni',
+          'TZS' => 'Tanzanian Shilling',
+          'THB' => 'Baht',
+          'TOP' => 'Paanga',
+          'TTD' => 'Trinidad and Tobago Dollar',
+          'TND' => 'Tunisian Dinar',
+          'TRY' => 'Turkish Lira',
+          'TMT' => 'Turkmenistan New Manat',
+          'UGX' => 'Uganda Shilling',
+          'UAH' => 'Hryvnia',
+          'AED' => 'UAE Dirham',
+          'USN' => 'US Dollar Next day',
+          'UYI' => 'Uruguay Peso en Unidades Indexadas URUIURUI',
+          'UYU' => 'Peso Uruguayo',
+          'UZS' => 'Uzbekistan Sum',
+          'VUV' => 'Vatu',
+          'VEF' => 'Bolivar',
+          'VND' => 'Dong',
+          'YER' => 'Yemeni Rial',
+          'ZMW' => 'Zambian Kwacha',
+          'ZWL' => 'Zimbabwe Dollar',
+          'XBA' => 'Bond Markets Unit European Composite Unit EURCO',
+          'XBB' => 'Bond Markets Unit European Monetary Unit EMU6',
+          'XBC' => 'Bond Markets Unit European Unit of Account 9 EUA9',
+          'XBD' => 'Bond Markets Unit European Unit of Account 17 EUA17',
+          'XTS' => 'Codes specifically reserved for testing purposes',
+          'XAU' => 'Gold',
+          'XPD' => 'Palladium',
+          'XPT' => 'Platinum',
+          'XAG' => 'Silver',
+        );
     }
 }

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -1,0 +1,22 @@
+<?php
+namespace Payu\Test;
+
+error_reporting(E_ALL | E_STRICT);
+define('TEST_MICROTIME', microtime(true));
+
+/**
+ * Test bootstrap, for setting up autoloading
+ */
+class Bootstrap
+{
+    public static function init()
+    {
+        chdir(dirname(__DIR__));
+        include('vendor/autoload.php');
+        if (!is_dir('tests/testresults')) {
+            mkdir('tests/testresults', 0755);
+        }
+    }
+}
+
+Bootstrap::init();

--- a/tests/CurrencyTest.php
+++ b/tests/CurrencyTest.php
@@ -14,39 +14,10 @@ class CurrencyTest extends \PHPUnit_Framework_TestCase
     public function testGoodCurrencyCodeWorks($code, $expected)
     {
         $cur = (string) new Currency($code);
+        
         $this->assertEquals($cur, $expected);
     }
-
-    /**
-     * @dataProvider badCurrencyProvider
-     * @expectedException InvalidArgumentException
-     */
-    public function testInvalidCurrencyCodeShouldThrowException($code)
-    {
-        $cur = new Currency();
-        $cur->setCode($code);
-    }
-
-    public function testCurrencyNameBehavior()
-    {
-        $code = 'TRY';
-        $label = 'Turkish Lira';
-
-        $this->assertEquals($label, Currency::getNameByCode($code));
-    }
-
-    public function badCurrencyProvider()
-    {
-        return [
-            ['trl'],
-            ['false'],
-            [true],
-            [-1],
-            ['Euro'],
-            ['XXX'],
-        ];
-    }
-
+    
     public function goodCurrencyProvider()
     {
         return array(
@@ -54,6 +25,7 @@ class CurrencyTest extends \PHPUnit_Framework_TestCase
           array('EUR', 'EUR'),
           array('GBP', 'GBP'),
           array('USD', 'USD'),
+          // Lowercase
           array('usd', 'USD'),
           array('gbp', 'GBP'),
           array('eur', 'EUR'),

--- a/tests/CurrencyTest.php
+++ b/tests/CurrencyTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Currency test
+ */
+namespace Payu\Test;
+
+use Payu\Component\Currency;
+
+class CurrencyTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider goodCurrencyProvider
+     */
+    public function testGoodCurrencyCodeWorks($code, $expected)
+    {
+        $cur = (string) new Currency($code);
+        $this->assertEquals($cur, $expected);
+    }
+
+    /**
+     * @dataProvider badCurrencyProvider
+     * @expectedException InvalidArgumentException
+     */
+    public function testInvalidCurrencyCodeShouldThrowException($code)
+    {
+        $cur = new Currency();
+        $cur->setCode($code);
+    }
+
+    public function testCurrencyNameBehavior()
+    {
+        $code = 'TRY';
+        $label = 'Turkish Lira';
+
+        $this->assertEquals($label, Currency::getNameByCode($code));
+    }
+
+    public function badCurrencyProvider()
+    {
+        return [
+            ['trl'],
+            ['false'],
+            [true],
+            [-1],
+            ['Euro'],
+            ['XXX'],
+        ];
+    }
+
+    public function goodCurrencyProvider()
+    {
+        return array(
+          array('TRY', 'TRY'),
+          array('EUR', 'EUR'),
+          array('GBP', 'GBP'),
+          array('USD', 'USD'),
+          array('usd', 'USD'),
+          array('gbp', 'GBP'),
+          array('eur', 'EUR'),
+          array('try', 'TRY'),
+        );
+    }
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="Bootstrap.php"
+         colors="true"
+         stopOnError="true"
+         stopOnFailure="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="Payu Test">
+            <directory>./</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./../src</directory>
+        </whitelist>
+    </filter>
+
+    <logging>
+
+        <log type="coverage-html" target="./testresults" />
+    </logging>
+
+</phpunit>


### PR DESCRIPTION
Selam @ibrahimgunduz34, #22 numaralı PR'ı reopen yapamadığım için bunu açıyorum. Currency iyileştirmesi + unit test + testler için dökümantasyon içeriyor. Bahsettiğin gibi, validasyon işlemini Currency componentinden çıkarıp OrderValidator'a taşıdım.

Bu PR'a alarak dokunduğum satır sayısını daha fazla arttırmak istemediğim ancak önemli olduğunu düşündüğüm bir konu var;

Product - order fiyatları, genel olarak tüm parayla ilgili işler için float yerine [money value object](https://github.com/sebastianbergmann/money) kullanmak bu kütüphane için epey yerinde bir iyileştirme olur. Bu durumda `Currency` component'ini deprecate etmek gerekebileceğinden ve bunu bazı yapısal  değişiklikliklerle devreye almak daha sağlıklı olacağından önce fikrini almak istedim.

Örneğin `setPrice(\Money\Money $price)` şeklinde bazı setter metodlarda type hinting kullanarak finansal değerlerin her zaman `Money` objesi olarak verilmesi sağlanabilir vs. (ya da setter içinde `is_scalar()` ile argüman değeri kontrol edilip obje otomatik yaratılabilir ama setter içinde obje yaratmak yerine ilgili tipteki objeyi parametre olarak almak bana daha sağlıklı geliyor.)

[Mathias Verraes'in money implementasyonu](https://github.com/mathiasverraes/money) da oldukça iyidir.
